### PR TITLE
Add reconciliation for raw and formatted Excel workbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A modern web application that processes multi-sheet Excel files to create format
 ## Features
 
 - **File Upload**: Drag & drop or select Excel files (.xlsx/.xls)
+- **Dual Upload & Reconciliation**: Combine updated raw workbooks with an existing formatted workbook, automatically merge new deals, and highlight any changed values in red
 - **Advanced Settings**: Configurable sheet names and column mappings
 - **Two-Step Processing**:
   - **Step 1**: Creates formatted report with headers A-V and applies styling

--- a/index.html
+++ b/index.html
@@ -47,22 +47,46 @@
                     <p>Upload your petroleum trading data for analysis</p>
                 </div>
                 <div class="upload-area">
-                    <input type="file" id="fileInput" accept=".xlsx,.xls" style="display: none;">
-                    <label for="fileInput" class="upload-zone">
-                        <div class="upload-icon">
-                            <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
-                            </svg>
+                    <div class="upload-section">
+                        <h3 class="upload-section-title">Raw Data Workbook</h3>
+                        <input type="file" id="fileInput" accept=".xlsx,.xls" style="display: none;">
+                        <label for="fileInput" class="upload-zone">
+                            <div class="upload-icon">
+                                <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
+                                </svg>
+                            </div>
+                            <div class="upload-text">
+                                <span class="upload-title">Select updated raw data</span>
+                                <span class="upload-subtitle">Drag & drop or click to browse</span>
+                            </div>
+                        </label>
+                        <div class="file-selected" id="fileInfo" style="display: none;">
+                            <div class="file-details">
+                                <span id="fileName"></span>
+                                <button id="clearFile" class="clear-btn">×</button>
+                            </div>
                         </div>
-                        <div class="upload-text">
-                            <span class="upload-title">Choose Excel File</span>
-                            <span class="upload-subtitle">Drag & drop or click to browse</span>
-                        </div>
-                    </label>
-                    <div class="file-selected" id="fileInfo" style="display: none;">
-                        <div class="file-details">
-                            <span id="fileName"></span>
-                            <button id="clearFile" class="clear-btn">×</button>
+                    </div>
+                    <div class="upload-section">
+                        <h3 class="upload-section-title">Existing formatted workbook</h3>
+                        <input type="file" id="existingFileInput" accept=".xlsx,.xls" style="display: none;">
+                        <label for="existingFileInput" class="upload-zone">
+                            <div class="upload-icon">
+                                <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
+                                </svg>
+                            </div>
+                            <div class="upload-text">
+                                <span class="upload-title">Select current formatted file</span>
+                                <span class="upload-subtitle">We&apos;ll highlight any differences</span>
+                            </div>
+                        </label>
+                        <div class="file-selected" id="existingFileInfo" style="display: none;">
+                            <div class="file-details">
+                                <span id="existingFileName"></span>
+                                <button id="clearExistingFile" class="clear-btn">×</button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -108,7 +132,7 @@
             <section class="analytics-dashboard" id="resultsSection" style="display: none;">
                 <div class="dashboard-header-section">
                     <h2>Analytics Overview</h2>
-                    <button id="downloadButton" class="download-btn">
+                    <button id="downloadButton" class="download-btn" disabled>
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z" />
                         </svg>

--- a/server.py
+++ b/server.py
@@ -390,6 +390,111 @@ class ExcelProcessor:
                     else:
                         cell.alignment = center_alignment
 
+    def highlight_differences(self, new_workbook: Workbook, existing_workbook: Workbook, settings: Dict[str, Any]) -> None:
+        """Compare with existing workbook and highlight differences in red"""
+
+        target_sheet_name = settings.get('output_sheet_name') or new_workbook.active.title
+
+        new_ws = new_workbook[target_sheet_name] if target_sheet_name in new_workbook.sheetnames else new_workbook.active
+
+        if not existing_workbook.sheetnames:
+            return
+
+        if target_sheet_name in existing_workbook.sheetnames:
+            existing_ws = existing_workbook[target_sheet_name]
+        else:
+            existing_ws = existing_workbook.active
+
+        existing_map: Dict[str, List[Any]] = {}
+
+        for row_idx in range(1, existing_ws.max_row + 1):
+            if row_idx == 1:
+                continue
+            vsa_value = existing_ws.cell(row=row_idx, column=2).value
+            key = self.normalize(vsa_value)
+            if not key:
+                continue
+            row_values = [existing_ws.cell(row=row_idx, column=col).value for col in range(1, 23)]
+            existing_map[key] = row_values
+
+        for row_idx in range(1, new_ws.max_row + 1):
+            if row_idx == 1:
+                continue
+            vsa_value = new_ws.cell(row=row_idx, column=2).value
+            key = self.normalize(vsa_value)
+            if not key:
+                continue
+
+            row_values = [new_ws.cell(row=row_idx, column=col).value for col in range(1, 23)]
+
+            if key in existing_map:
+                old_values = existing_map[key]
+                for col_idx in range(1, 23):
+                    new_cell = new_ws.cell(row=row_idx, column=col_idx)
+                    new_val = row_values[col_idx - 1]
+                    old_val = old_values[col_idx - 1] if col_idx - 1 < len(old_values) else None
+                    if self.values_different(new_val, old_val) and self.should_highlight_cell(col_idx, new_val, old_val):
+                        self.apply_font_color(new_cell, 'FFFF0000')
+            else:
+                for col_idx in range(1, 23):
+                    cell = new_ws.cell(row=row_idx, column=col_idx)
+                    if self.should_highlight_cell(col_idx, cell.value, None):
+                        self.apply_font_color(cell, 'FFFF0000')
+
+    def apply_font_color(self, cell, color: str) -> None:
+        """Update cell font color while preserving other attributes"""
+
+        existing_font = cell.font if cell.font else Font()
+        cell.font = Font(
+            name=existing_font.name,
+            size=existing_font.size,
+            bold=existing_font.bold,
+            italic=existing_font.italic,
+            vertAlign=existing_font.vertAlign,
+            underline=existing_font.underline,
+            strike=existing_font.strike,
+            color=color
+        )
+
+    def should_highlight_cell(self, col_idx: int, new_val: Any, old_val: Any) -> bool:
+        """Determine if a cell should be highlighted"""
+
+        if col_idx == 1:
+            return False
+
+        if new_val is None and (old_val is None or old_val == ''):
+            return False
+
+        if isinstance(new_val, str):
+            return bool(new_val.strip())
+
+        return True
+
+    def values_different(self, new_val: Any, old_val: Any) -> bool:
+        """Check if two values should be considered different"""
+
+        if new_val is None and (old_val is None or old_val == ''):
+            return False
+
+        if self.is_numeric(new_val) and self.is_numeric(old_val):
+            try:
+                return abs(float(new_val) - float(old_val)) > 1e-6
+            except Exception:
+                pass
+
+        norm_new = self.normalize(new_val)
+        norm_old = self.normalize(old_val)
+        return norm_new != norm_old
+
+    def is_numeric(self, value: Any) -> bool:
+        try:
+            if value is None or value == '':
+                return False
+            float(value)
+            return True
+        except (TypeError, ValueError):
+            return False
+
     def normalize(self, value) -> str:
         """Normalize values for consistent comparison"""
         return str(value).strip().upper() if value else ''
@@ -466,6 +571,56 @@ async def process_excel(
 
         return StreamingResponse(
             BytesIO(output_buffer.getvalue()),
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            headers=headers
+        )
+
+    except Exception as e:
+        return {"error": str(e)}
+
+@app.post("/reconcile")
+async def reconcile_excels(
+    raw_file: UploadFile,
+    formatted_file: UploadFile,
+    output_sheet_name: str = Form("Q1-Q2-Q3-Q4-2024"),
+    raw_sheet1_name: str = Form(""),
+    raw_sheet2_name: str = Form(""),
+    raw_sheet3_name: str = Form(""),
+    deal_column_name: str = Form("N")
+):
+    """Process raw data, compare with existing workbook, and highlight differences"""
+
+    try:
+        raw_data = await raw_file.read()
+        formatted_data = await formatted_file.read()
+
+        settings = {
+            'output_sheet_name': output_sheet_name,
+            'raw_sheet1_name': raw_sheet1_name if raw_sheet1_name else None,
+            'raw_sheet2_name': raw_sheet2_name if raw_sheet2_name else None,
+            'raw_sheet3_name': raw_sheet3_name if raw_sheet3_name else None,
+            'deal_column_name': deal_column_name
+        }
+
+        processor = ExcelProcessor()
+        processed_buffer = processor.process_excel_file(raw_data, settings)
+        processed_buffer.seek(0)
+
+        new_workbook = load_workbook(processed_buffer)
+        existing_workbook = load_workbook(BytesIO(formatted_data), data_only=True)
+
+        processor.highlight_differences(new_workbook, existing_workbook, settings)
+
+        output = BytesIO()
+        new_workbook.save(output)
+        output.seek(0)
+
+        headers = {
+            "Content-Disposition": "attachment; filename=reconciled_output.xlsx"
+        }
+
+        return StreamingResponse(
+            output,
             media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             headers=headers
         )

--- a/styles.css
+++ b/styles.css
@@ -221,7 +221,22 @@ body, .dashboard, .dashboard-main, .dashboard-header {
 
 /* Upload Area */
 .upload-area {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--space-lg);
     margin-bottom: var(--space-xl);
+}
+
+.upload-section {
+    display: flex;
+    flex-direction: column;
+}
+
+.upload-section-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--gray-800);
+    margin-bottom: var(--space-md);
 }
 
 .upload-zone {
@@ -460,7 +475,14 @@ body, .dashboard, .dashboard-main, .dashboard-header {
     box-shadow: var(--shadow-sm);
 }
 
-.download-btn:hover {
+.download-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    filter: none;
+    transform: none;
+}
+
+.download-btn:not(:disabled):hover {
     filter: brightness(1.05);
     transform: translateY(-1px);
 }


### PR DESCRIPTION
## Summary
- add dual workbook upload flow in the dashboard so users can provide both the raw data file and the existing formatted file
- extend the JavaScript client to validate both files, toggle actions appropriately, and request the new reconciliation endpoint before downloading
- implement backend reconciliation logic that processes the latest raw workbook, compares it with the uploaded formatted workbook, highlights differences in red, and exposes it through a /reconcile API
- refresh styles and documentation to describe the new reconciliation capability

## Testing
- python -m py_compile server.py

------
https://chatgpt.com/codex/tasks/task_e_68ca7b0eb79083299cffd32db6e254c9